### PR TITLE
removing reference to untracked image file in csproj file

### DIFF
--- a/CustomGUI/CustomGUI.csproj
+++ b/CustomGUI/CustomGUI.csproj
@@ -25,9 +25,6 @@
     <Resource Include="img\folder_icon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>
-    <Resource Include="img\upload.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The file `img\upload.png` was not tracked in the repository so far. Consider to commit the source file or merge this PR to unblock the build process